### PR TITLE
Added occupancy sensor support based on Homey presence state.

### DIFF
--- a/api.js
+++ b/api.js
@@ -47,5 +47,36 @@ module.exports = [
         });
 
     }
-  }
+  },
+  {
+    method: 'GET',
+    path: '/users',
+    fn: function(args, callback) {
+      Homey.app .getUsers()
+                .then(res => callback(null, res))
+                .catch(callback);
+    }
+  },
+  {
+    method: 'PUT',
+    path: '/users',
+    fn: function(args, callback) {
+      let user = args.body;
+      console.log('API call received, trying to track ' + user.name, 'info');
+      Homey.app .trackUser(user)
+                .then(res => callback(null, true))
+                .catch(callback);
+    }
+  },
+  {
+    method: 'DELETE',
+    path: '/users',
+    fn: function(args, callback) {
+      let user = args.body;
+      console.log('API call received, trying to untrack ' + user.name, 'info');
+      Homey.app .unTrackUser(user)
+                .then(res => callback(null, true))
+                .catch(callback);
+    }
+  },
 ]

--- a/lib/homekit.js
+++ b/lib/homekit.js
@@ -42,7 +42,6 @@ function configServer(homey)
   return server;
 }
 
-
 function map(inputStart, inputEnd, outputStart, outputEnd, input)
 {
   return outputStart + ((outputEnd - outputStart) / (inputEnd - inputStart)) * (input - inputStart);
@@ -980,8 +979,6 @@ function createDevice(device, id)
     capabilities = [];
   }
 
-
-
   device.on('$state', state =>
   {
 
@@ -1355,8 +1352,75 @@ function createDevice(device, id)
 
 }
 
+class OccupancyManager {
+  constructor(server, api) {
+    this.server = server;
+    this.api    = api;
+    this.users  = {};
+  }
+
+  idForUser(user) {
+    return this.server.config.getHASID(user.id);
+  }
+
+  async trackUser(user) {
+    if (user.id in this.users) return;
+    let characteristic  = await this.createAccessory(user);
+    this.users[user.id] = Object.assign({}, user, { characteristic });
+    console.log('Tracking user', user.name);
+  }
+
+  async unTrackUser(user) {
+    if (! (user.id in this.users)) return;
+    this.server.removeAccessory(this.idForUser(user));
+    delete this.users[user.id];
+    console.log(`Not tracking user ${ user.name } anymore`);
+  }
+
+  async createAccessory(user) {
+    const accessory       = new HAS.Accessory(this.idForUser(user));
+    let serviceNum        = 1;
+    let characteristicNum = 1;
+
+    // Create accessory information.
+    const identify        = HAS.predefined.Identify(characteristicNum++, undefined, (value, callback) => callback(HAS.statusCodes.OK));
+    const manufacturer    = HAS.predefined.Manufacturer(characteristicNum++, 'Athom');
+    const model           = HAS.predefined.Model(characteristicNum++, 'Homey');
+    const name            = HAS.predefined.Name(characteristicNum++, user.name);
+    const serialNumber    = HAS.predefined.SerialNumber(characteristicNum++, user.id);
+    const firmwareVersion = HAS.predefined.FirmwareRevision(characteristicNum++, '1.0.0');
+    accessory.addServices(HAS.predefined.AccessoryInformation(serviceNum++, [identify, manufacturer, model, name, serialNumber, firmwareVersion]));
+
+    // Create occupancy sensor.
+    const characteristic = HAS.predefined.OccupancyDetected(1, this.stateToValue(false));
+    accessory.addServices(HAS.predefined.OccupancySensor(serviceNum++, [ characteristic ]));
+
+    // Add to server.
+    await this.server.addAccessory(accessory);
+
+    // Return characteristic (used to toggle the state).
+    return characteristic;
+  }
+
+  async updateState(state) {
+    const { user_id, present } = state;
+    const user                 = this.users[user_id];
+
+    // Update status if we're tracking this user.
+    if (user) {
+      user.characteristic.setValue(this.stateToValue(present));
+      console.log(`Set occupancy state for ${ user.name } (${ user.id }) to ${ present }`);
+    }
+  }
+
+  stateToValue(state) {
+    return state ? 1 : 0;
+  }
+
+}
 
 module.exports = {
   configServer: configServer,
-  createDevice: createDevice
+  createDevice: createDevice,
+  OccupancyManager
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,11 +1,15 @@
 {
-
   "tabs": {
     "devices": "Devices",
+    "presence": "Presence",
     "log": "Log"
   },
   "device": {
     "add": "Add",
     "delete": "Delete"
+  },
+  "user": {
+    "track": "Track",
+    "untrack": "Untrack"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,11 +1,16 @@
 {
-
   "tabs": {
     "devices": "Apparaten",
+    "presence": "Aanwezigheid",
     "log": "Log"
   },
   "device": {
     "add": "Toevoegen",
     "delete": "Verwijderen"
+  },
+  "user": {
+    "description" : "Je kunt de aanwezigheid van gebruikers volgen.",
+    "track": "Volg",
+    "untrack": "Ontvolg"
   }
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -16,11 +16,15 @@
           <li v-bind:class="isActive('devices')">
             <a @click="setPage('devices')" data-i18n="tabs.devices">Devices</a>
           </li>
+          <li v-bind:class="isActive('presence')">
+            <a @click="setPage('presence')" data-i18n="tabs.presence">Presence</a>
+          </li>
           <li v-bind:class="isActive('log')">
             <a @click="setPage('log')" data-i18n="tabs.log">Log</a>
           </li>
         </ul>
       </div>
+
       <!-- DEVICES PAGE -->
       <div class="columns is-multiline" v-if="currentPage == 'devices'">
         <input v-model="search" class="input" style="margin-left:10px;margin-right:10px;" type="text" placeholder="Filter...">
@@ -37,6 +41,22 @@
         </div>
       </div>
 
+      <!-- PRESENCE PAGE -->
+      <div class="columns is-multiline" v-if="currentPage == 'presence'">
+        <div class="column is-3" v-for="user in users">
+          <div class="box">
+            <center>
+              <img :src="user.avatar" style="height:40px;width:auto;border-radius:20px"/><br/>
+              <b>{{ user.name }}</b><br/>
+              <small>{{ user.role }} | {{ user.email }}</small><br/>
+              <a v-if="!isTracked(user)" @click="trackUser(user)" class="button is-success is-outlined " style="margin:5px;" data-i18n="user.track">Track</a>
+              <a v-if=" isTracked(user)" @click="unTrackUser(user)" class="button is-outlined is-danger" style="margin:5px;" data-i18n="user.untrack">Untrack</a>
+            </center>
+          </div>
+        </div>
+      </div>
+
+      <!-- LOG PAGE -->
       <div class="columns is-multiline" style="margin-left:8px;margin-right:2px;" v-if="currentPage == 'log'">
         <div class="column is-12 box">
           <table class="table is-striped">
@@ -64,8 +84,10 @@
         el: '#app',
         data: {
           devices: {},
-          search: '',
           devicesPaired: [],
+          users: [],
+          usersTracked: [],
+          search: '',
           currentPage: 'devices',
           log: []
         },
@@ -78,6 +100,14 @@
                 return result[key];
               });
               this.devices = array;
+            });
+          },
+          getUsers() {
+            Homey.api('GET', '/users', null, (err, result) => {
+              if (err) {
+                return Homey.alert(err);
+              }
+              this.users = result || [];
             });
           },
           getLog() {
@@ -93,7 +123,13 @@
               if (result) {
                 this.devicesPaired = result;
               }
-
+            });
+          },
+          getTrackedUsers() {
+            Homey.get('trackedUsers', (err, result) => {
+              if (result) {
+                this.usersTracked = result;
+              }
             });
           },
           setPage(page) {
@@ -141,6 +177,29 @@
               }
             );
           },
+          trackUser(user) {
+            Homey.api('PUT', '/users', user, (err, result) => {
+              if (err) {
+                return Homey.alert(err);
+              }
+              console.log('Tracking', user.name);
+              this.usersTracked.push(user);
+              Homey.set('trackedUsers', this.usersTracked);
+            });
+          },
+          unTrackUser(user) {
+            Homey.api('DELETE', '/users', user, (err, result) => {
+              if (err) {
+                return Homey.alert(err);
+              }
+              console.log('Untracking', user.name);
+              let idx = this.usersTracked.findIndex(u => u.id === user.id);
+              if (idx !== -1) {
+                this.usersTracked.splice(idx, 1);
+                Homey.set('trackedUsers', this.usersTracked);
+              }
+            });
+          },
           isAdded(obj) {
             var i;
             for (i = 0; i < this.devicesPaired.length; i++) {
@@ -148,8 +207,10 @@
                 return true;
               }
             }
-
             return false;
+          },
+          isTracked(obj) {
+            return this.usersTracked.find(user => user.id === obj.id) ? true : false;
           },
           filterArray(device) {
             if (device.class == "light" || device.class == "socket" || device.class == "sensor" || device.class == "lock")
@@ -159,6 +220,9 @@
         mounted() {
           this.getPairedDevices();
           this.getDevices();
+          this.getTrackedUsers();
+          this.getDevices();
+          this.getUsers();
           this.getLog();
           Homey.on('log.new', (res)=>{
             this.log = res;


### PR DESCRIPTION
I thought it would be nice to map presence state, as maintained by Homey, to a HomeKit `OccupancySensor` (strictly speaking, these are meant for devices that track _room_ occupancy, whereas Homey tracks what amounts to _home_ occupancy).

I use `nl.terryhendrix.smartpresence` in a flow that sets presence state, and any changes will be reflected in the state of the sensor.

Tracking a user's presence is entirely optional, which means that for each registered Homey user you can set their "tracked" state in the Settings. When a user is being tracked, an `OccupancySensor` is added to the HAS, and when the user is untracked, that sensor is removed.